### PR TITLE
Fix docs deploy workflow

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -9,16 +9,13 @@ jobs:
   build:
     name: Build docs
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.11"
 
       - name: Install build deps
         run: |
@@ -29,6 +26,11 @@ jobs:
         run: |
           mkdocs build --clean
 
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
   deploy:
     name: Deploy to GitHub Pages
     needs: build
@@ -38,8 +40,5 @@ jobs:
       pages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
-        with:
-          path: site
+      - name: Deploy
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- simplify the docs build job to a single Python version and upgrade to the latest setup-python action
- upload the generated MkDocs site from the build job as the GitHub Pages artifact
- add an explicit deploy step that publishes the uploaded site via actions/deploy-pages

## Testing
- not run (workflow change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919fa311c8883279be089a95f663450)

## Summary by Sourcery

Simplify and modernize the GitHub Actions docs deployment workflow by using a single Python version, upgrading setup-python, uploading the built site as an artifact, and switching to the deploy-pages action for publishing.

CI:
- Run the docs build job only on Python 3.11 and upgrade actions/setup-python from v4 to v5
- Upload the generated MkDocs site with actions/upload-pages-artifact@v3 in the build job
- Replace the manual checkout and upload in the deploy job with a single actions/deploy-pages@v4 step