### PR TITLE
Fix Docs workflow deploy job on pull requests

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -33,6 +33,7 @@ jobs:
 
   deploy:
     name: Deploy to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: build
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
### Motivation
- The GitHub Pages `deploy` job was running for `pull_request` events where Pages write/id-token permissions are typically unavailable, causing the Docs action to fail.

### Description
- Add a job-level condition to `.github/workflows/docs-deploy.yml`: `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` so the `deploy` job only runs on pushes to `main` while the `build` job still runs for PRs.

### Testing
- Ran `git diff -- .github/workflows/docs-deploy.yml` to confirm the single-line insertion and `git show --stat --oneline HEAD` to confirm the commit, and attempted YAML validation with `python - <<'PY' ... PY` which could not run because `PyYAML` is not installed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d62bedd108833283bfd360453d22f4)

## Summary by Sourcery

CI:
- Add a job-level condition to the docs deploy workflow so the deploy job only runs for push events on the main branch, avoiding failures on pull requests.